### PR TITLE
Add JavaDoc comments to ElasticsearchDataStore and ElasticsearchListDataStore classes

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchDataStore.java
@@ -48,27 +48,64 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.transport.client.Client;
 
+/**
+ * DataStore for Elasticsearch.
+ */
 public class ElasticsearchDataStore extends AbstractDataStore {
 
     private static final Logger logger = LogManager.getLogger(ElasticsearchDataStore.class);
 
+    /**
+     * A preference of which shard replicas to execute the search request on.
+     */
     protected static final String PREFERENCE = "preference";
 
+    /**
+     * The query to execute.
+     */
     protected static final String QUERY = "query";
 
+    /**
+     * The fields to retrieve.
+     */
     protected static final String FIELDS = "fields";
 
+    /**
+     * The number of hits to return.
+     */
     protected static final String SIZE = "size";
 
+    /**
+     * The timeout for the request.
+     */
     protected static final String TIMEOUT = "timeout";
 
+    /**
+     * The scroll timeout.
+     */
     protected static final String SCROLL = "scroll";
 
+    /**
+     * The index to search.
+     */
     protected static final String INDEX = "index";
 
+    /**
+     * The prefix for Elasticsearch settings.
+     */
     protected static final String SETTINGS_PREFIX = "settings.";
 
+    /**
+     * The pattern for Elasticsearch settings. The value is {@code ^settings\.}.
+     */
     protected static final String SETTINGS_PATTERN = "^settings\\.";
+
+    /**
+     * Constructor.
+     */
+    public ElasticsearchDataStore() {
+        super();
+    }
 
     @Override
     protected String getName() {
@@ -91,8 +128,19 @@ public class ElasticsearchDataStore extends AbstractDataStore {
         }
     }
 
+    /**
+     * Process the data from Elasticsearch.
+     * @param dataConfig The data configuration.
+     * @param callback The callback to index the data.
+     * @param paramMap The parameters for the data store.
+     * @param scriptMap The script map.
+     * @param defaultDataMap The default data map.
+     * @param readInterval The read interval.
+     * @param client The Elasticsearch client.
+     */
     protected void processData(final DataConfig dataConfig, final IndexUpdateCallback callback, final DataStoreParams paramMap,
             final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap, final long readInterval, final Client client) {
+
         final CrawlerStatsHelper crawlerStatsHelper = ComponentUtil.getCrawlerStatsHelper();
         final boolean deleteProcessedDoc = Constants.TRUE.equalsIgnoreCase(paramMap.getAsString("delete.processed.doc", Constants.FALSE));
         final String[] indices = paramMap.getAsString(INDEX, "_all").trim().split(",");

--- a/src/main/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchListDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchListDataStore.java
@@ -28,8 +28,19 @@ import org.codelibs.fess.exception.DataStoreException;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
+/**
+ * DataStore for Elasticsearch.
+ * This class is for listing files from Elasticsearch.
+ */
 public class ElasticsearchListDataStore extends ElasticsearchDataStore {
     private static final Logger logger = LogManager.getLogger(ElasticsearchListDataStore.class);
+
+    /**
+     * Constructor.
+     */
+    public ElasticsearchListDataStore() {
+        super();
+    }
 
     @Override
     protected String getName() {


### PR DESCRIPTION
This pull request adds JavaDoc comments to the ElasticsearchDataStore and ElasticsearchListDataStore classes to improve code readability and maintainability. The documentation includes descriptions for class-level purposes, constants, constructors, and method parameters.
