### PR TITLE
Bump to 15.2.0-SNAPSHOT and format Settings builder chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-elasticsearch</artifactId>
 	<packaging>jar</packaging>
 	<name>Elasticsearch Data Store</name>
-	<version>15.1.1-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-elasticsearch.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-elasticsearch.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.2.0</version>
 		<relativePath />
 	</parent>
 	<build>

--- a/src/main/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchDataStore.java
@@ -118,10 +118,15 @@ public class ElasticsearchDataStore extends AbstractDataStore {
 
         final long readInterval = getReadInterval(paramMap);
 
-        final Settings settings = Settings.builder().putProperties(
-                paramMap.asMap().entrySet().stream().filter(e -> e.getKey().startsWith(SETTINGS_PREFIX)).collect(
-                        Collectors.toMap(e -> e.getKey().replaceFirst(SETTINGS_PATTERN, StringUtil.EMPTY), e -> (String) e.getValue())),
-                s -> s).build();
+        final Settings settings = Settings.builder()
+                .putProperties(paramMap.asMap()
+                        .entrySet()
+                        .stream()
+                        .filter(e -> e.getKey().startsWith(SETTINGS_PREFIX))
+                        .collect(Collectors.toMap(e -> e.getKey().replaceFirst(SETTINGS_PATTERN, StringUtil.EMPTY),
+                                e -> (String) e.getValue())),
+                        s -> s)
+                .build();
 
         try (Client client = new HttpClient(settings, null);) {
             processData(dataConfig, callback, paramMap, scriptMap, defaultDataMap, readInterval, client);


### PR DESCRIPTION
This pull request updates the Elasticsearch Data Store to be compatible with the upcoming 15.2.0 release and improves code readability in the settings initialization. The most important changes are grouped below:

Version updates:

* Updated the project version in `pom.xml` from `15.1.1-SNAPSHOT` to `15.2.0-SNAPSHOT` to prepare for the next release.
* Updated the parent artifact version in `pom.xml` from `15.1.0` to `15.2.0` for consistency with the main project.

Code readability improvements:

* Reformatted the `Settings` initialization in `ElasticsearchDataStore.java` for better readability and maintainability without changing functionality.