### PR TITLE
chore: bump version to 15.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-elasticsearch</artifactId>
 	<packaging>jar</packaging>
 	<name>Elasticsearch Data Store</name>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-elasticsearch.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-elasticsearch.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
This PR updates the project version to 15.3.0-SNAPSHOT in preparation for the next development cycle.

## Changes Made
- Updated project version from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT` in pom.xml
- Updated parent version from `15.2.0` to `15.3.0` in pom.xml

## Testing
No testing required as this is a version bump only.

## Breaking Changes
None

## Additional Notes
This is a routine version bump to align with the new development cycle.