### PR TITLE
chore: bump version to 15.4.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-elasticsearch</artifactId>
 	<packaging>jar</packaging>
 	<name>Elasticsearch Data Store</name>
-	<version>15.3.1-SNAPSHOT</version>
+	<version>15.4.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-elasticsearch.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-elasticsearch.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0</version>
+		<version>15.4.0</version>
 		<relativePath />
 	</parent>
 	<build>

--- a/src/test/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/elasticsearch/ElasticsearchDataStoreTest.java
@@ -300,9 +300,7 @@ public class ElasticsearchDataStoreTest extends LastaFluteTestCase {
         params.put("other.param", "value");
 
         Map<String, Object> paramsMap = params.asMap();
-        long settingsCount = paramsMap.entrySet().stream()
-                .filter(e -> ((String) e.getKey()).startsWith("settings."))
-                .count();
+        long settingsCount = paramsMap.entrySet().stream().filter(e -> ((String) e.getKey()).startsWith("settings.")).count();
 
         assertEquals(2, settingsCount);
     }
@@ -362,12 +360,10 @@ public class ElasticsearchDataStoreTest extends LastaFluteTestCase {
         Map<String, Object> paramsMap = params.asMap();
         Map<String, String> settingsMap = new HashMap<>();
 
-        paramsMap.entrySet().stream()
-                .filter(e -> ((String) e.getKey()).startsWith("settings."))
-                .forEach(e -> {
-                    String key = ((String) e.getKey()).replaceFirst("^settings\\.", "");
-                    settingsMap.put(key, (String) e.getValue());
-                });
+        paramsMap.entrySet().stream().filter(e -> ((String) e.getKey()).startsWith("settings.")).forEach(e -> {
+            String key = ((String) e.getKey()).replaceFirst("^settings\\.", "");
+            settingsMap.put(key, (String) e.getValue());
+        });
 
         assertEquals(3, settingsMap.size());
         assertEquals("test-cluster", settingsMap.get("cluster.name"));


### PR DESCRIPTION
## Summary

This PR updates the project version to 15.4.0-SNAPSHOT in preparation for the next development cycle.

## Changes Made

- **pom.xml**:
  - Updated artifact version from `15.3.1-SNAPSHOT` to `15.4.0-SNAPSHOT`
  - Updated parent `fess-parent` version from `15.3.0` to `15.4.0`
- **ElasticsearchDataStoreTest.java**:
  - Applied minor code formatting improvements to stream operations for better readability

## Testing

- No functional changes; version bump only
- Existing tests should continue to pass

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)